### PR TITLE
Add codecov.io reports using Istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .vscode
 npm-debug.log
 .idea/*
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,10 @@ node_js:
     - "node"
 services: mongodb
 env: "MONGODB_URI='mongodb://localhost:27017/fiddles'"
+install:
+    - npm install -g codecov
+    - npm install -g istanbul
+script:
+    - "istanbul cover _mocha"
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ node_js:
     - "node"
     - "7"
     - "6"
-    - "5"
-    - "4"
-    - "0.12"
-    - "0.10"
 services: mongodb
 env: "MONGODB_URI='mongodb://localhost:27017/fiddles'"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ node_js:
 services: mongodb
 env: "MONGODB_URI='mongodb://localhost:27017/fiddles'"
 install:
-    - npm install -g codecov
+    - npm install -g mocha
     - npm install -g istanbul
+    - npm install 
 script:
     - "istanbul cover _mocha"
 after_success:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "codecov": "1.0.1",
     "cross-env": "3.1.4",
     "eslint": "^3.13.1",
     "grunt": "^1.0.1",
@@ -52,6 +53,7 @@
     "grunt-inline": "0.3.6",
     "grunt-jscs": "^3.0.1",
     "grunt-lesslint": "^3.2.0",
+    "istanbul": "0.4.5",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^3.2.0",
     "supertest": "^2.0.1"


### PR DESCRIPTION
Add codecov.io reports using Istanbul.

This will require more configuration in the future but a good insight on code coverage for now.