### PR TITLE
Add PR and Issue template for github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+#### Type of issue
+- [ ] Bug
+- [ ] Idea/Suggestion
+- [ ] Question

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+#### Pre-Submission Checklist
+- [ ] Your pull request targets the `develop` branch.
+- [ ] Branch starts with either `fix/` or `feature/`
+- [ ] All new and existing tests pass the command `npm test`.
+
+#### Type of Change
+- [ ] Small bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds new functionality)
+- [ ] Breaking change (fix or feature that would change existing functionality)
+
+#### Checklist:
+- [ ] Tested changes locally.
+- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX
+
+#### Full Description of your Changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 - [ ] Your pull request targets the `develop` branch.
 - [ ] Branch starts with either `fix/` or `feature/`
 - [ ] All new and existing tests pass the command `npm test`.
+- [ ] Any new files are included in the grunt tasks
 
 #### Type of Change
 - [ ] Small bug fix (non-breaking change which fixes an issue)
@@ -10,6 +11,7 @@
 
 #### Checklist:
 - [ ] Tested changes locally.
+- [ ] New tests added?
 - [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX
 
 #### Full Description of your Changes


### PR DESCRIPTION
This PR will add templates for Github issues and PR's.
This is to ensure that both maintainers and contributors have an easier time knowing the expectations. 

I'll find it personally useful as I sometimes forget these things for making a PR! 🤕 