### PR TITLE
Improve Small Screen Support

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5192,7 +5192,7 @@ a:hover {
   }
   .header {
     font-size: 14px;
-    overflow-x: scroll;
+    overflow-x: visible;
   }
 }
 


### PR DESCRIPTION
Remove scroll bar from header on screens smaller than 768px

#### Pre-Submission Checklist
- [x] Your pull request targets the `develop` branch.
- [x] Branch starts with either `fix/` or `feature/`
- [x] All new and existing tests pass the command `npm test`.
- [x] Any new files are included in the grunt tasks

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] Tested changes locally.
- [ ] New tests added?
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #123 

#### Full Description of your Changes
Scroll bar was appearing in header on screens 768px and less.
Issue has been fixed by updating appropriate CSS styles.
The CSS style is specific for screens 768px and less.
Also, the style has been used only for the affected item i.e. header.

Before applying fix (width 375px)
![before_width_375px](https://user-images.githubusercontent.com/16874651/27398776-3e7773c2-56d4-11e7-8f14-9d296776f814.png)

After applying fix (width 360px)
![after_width_360px](https://user-images.githubusercontent.com/16874651/27398811-5e403a2c-56d4-11e7-8bc8-5db678ad62f9.png)
