### PR TITLE
fix/ Small layout size improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "optional": true,
       "requires": {
         "ansi-wrap": "0.1.0"
       }
@@ -146,8 +145,7 @@
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-      "optional": true
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
     "anymatch": {
       "version": "1.3.2",
@@ -1024,8 +1022,7 @@
     "beeper": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-      "optional": true
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
     },
     "better-assert": {
       "version": "1.0.2",
@@ -1809,8 +1806,7 @@
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "optional": true
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1821,7 +1817,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
-      "optional": true,
       "requires": {
         "get-proxy": "^1.0.1",
         "is-obj": "^1.0.0",
@@ -1832,14 +1827,12 @@
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "optional": true
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "optional": true
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
@@ -2100,8 +2093,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "optional": true
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colors": {
       "version": "1.1.2",
@@ -2389,7 +2381,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "optional": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
@@ -2849,8 +2840,7 @@
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "optional": true
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3085,7 +3075,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
-      "optional": true,
       "requires": {
         "caw": "^1.0.1",
         "concat-stream": "^1.4.7",
@@ -4058,7 +4047,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-      "optional": true,
       "requires": {
         "ansi-gray": "^0.1.1",
         "color-support": "^1.1.3",
@@ -4147,14 +4135,12 @@
     "filename-reserved-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-      "optional": true
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
     },
     "filenamify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
-      "optional": true,
       "requires": {
         "filename-reserved-regex": "^1.0.0",
         "strip-outer": "^1.0.0",
@@ -4423,7 +4409,6 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -4445,8 +4430,7 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -4460,13 +4444,11 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -4477,18 +4459,15 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -4523,8 +4502,7 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -4551,8 +4529,7 @@
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -4564,9 +4541,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -4649,8 +4626,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -4661,7 +4638,6 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -4703,9 +4679,8 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -4715,8 +4690,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -4779,22 +4753,20 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -4853,8 +4825,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -4903,8 +4874,7 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -4937,7 +4907,6 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -4986,8 +4955,7 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.3.0",
@@ -5007,7 +4975,6 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -5038,7 +5005,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5048,7 +5014,6 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -5073,7 +5038,6 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -5123,8 +5087,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -5186,7 +5149,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
-      "optional": true,
       "requires": {
         "rc": "^1.1.2"
       }
@@ -5376,7 +5338,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-      "optional": true,
       "requires": {
         "sparkles": "^1.0.0"
       }
@@ -5385,7 +5346,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-      "optional": true,
       "requires": {
         "create-error-class": "^3.0.1",
         "duplexer2": "^0.1.4",
@@ -6098,7 +6058,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
-      "optional": true,
       "requires": {
         "archive-type": "^3.0.0",
         "decompress": "^3.0.0",
@@ -6109,8 +6068,7 @@
     "gulp-rename": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
-      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
-      "optional": true
+      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
@@ -6138,7 +6096,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "optional": true,
       "requires": {
         "array-differ": "^1.0.0",
         "array-uniq": "^1.0.2",
@@ -6163,14 +6120,12 @@
         "dateformat": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-          "optional": true
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "optional": true
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "replace-ext": {
           "version": "0.0.1",
@@ -6181,7 +6136,6 @@
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -6194,7 +6148,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "optional": true,
       "requires": {
         "glogg": "^1.0.0"
       }
@@ -6340,7 +6293,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "optional": true,
       "requires": {
         "sparkles": "^1.0.0"
       }
@@ -6691,8 +6643,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "optional": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inline-source-map": {
       "version": "0.6.2",
@@ -6965,8 +6916,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "optional": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -7013,8 +6963,7 @@
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "optional": true
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -7037,8 +6986,7 @@
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "optional": true
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -7072,8 +7020,7 @@
     "is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "optional": true
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -7992,44 +7939,37 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "optional": true
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._basetostring": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "optional": true
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
     },
     "lodash._basevalues": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "optional": true
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "optional": true
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "optional": true
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
     },
     "lodash._reescape": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-      "optional": true
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-      "optional": true
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -8087,14 +8027,12 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "optional": true
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "optional": true
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -8110,7 +8048,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "optional": true,
       "requires": {
         "lodash._getnative": "^3.0.0",
         "lodash.isarguments": "^3.0.0",
@@ -8150,8 +8087,7 @@
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "optional": true
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
     },
     "lodash.some": {
       "version": "4.6.0",
@@ -8162,7 +8098,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "optional": true,
       "requires": {
         "lodash._basecopy": "^3.0.0",
         "lodash._basetostring": "^3.0.0",
@@ -8179,7 +8114,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "optional": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.escape": "^3.0.0"
@@ -8232,8 +8166,7 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "optional": true
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lpad-align": {
       "version": "1.1.2",
@@ -8750,7 +8683,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "optional": true,
       "requires": {
         "duplexer2": "0.0.2"
       },
@@ -8759,7 +8691,6 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "optional": true,
           "requires": {
             "readable-stream": "~1.1.9"
           }
@@ -8767,14 +8698,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "optional": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -8785,8 +8714,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "optional": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -8834,8 +8762,7 @@
     "node-status-codes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "optional": true
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
     "nomnom": {
       "version": "1.8.1",
@@ -9094,8 +9021,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "optional": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.2.0",
@@ -9424,8 +9350,7 @@
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "optional": true
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "preserve": {
       "version": "0.2.0",
@@ -9624,7 +9549,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
-      "optional": true,
       "requires": {
         "deep-extend": "~0.4.0",
         "ini": "~1.3.0",
@@ -10634,7 +10558,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -10874,14 +10797,12 @@
     "time-stamp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-      "optional": true
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
     },
     "timed-out": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-      "optional": true
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
     },
     "timers-browserify": {
       "version": "1.4.2",
@@ -11084,7 +11005,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -11231,8 +11151,7 @@
     "unzip-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "optional": true
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -11274,7 +11193,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "optional": true,
       "requires": {
         "prepend-http": "^1.0.1"
       }
@@ -11494,7 +11412,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
-      "optional": true,
       "requires": {
         "wrap-fn": "^0.1.0"
       }
@@ -11746,7 +11663,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
       "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
-      "optional": true,
       "requires": {
         "co": "3.1.0"
       },
@@ -11754,8 +11670,7 @@
         "co": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
-          "optional": true
+          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
         }
       }
     },

--- a/style/components/buttons.less
+++ b/style/components/buttons.less
@@ -39,7 +39,7 @@
     flex-direction: column;
     align-items: flex-start;
     width: 200px;
-    font-size: 12px;
+    font-size: 1.2rem;
     visibility: hidden;
     opacity: 0;
     transition: visibility 0s, opacity 200ms ease;

--- a/style/components/content.less
+++ b/style/components/content.less
@@ -36,7 +36,7 @@
     width: 100%;
     background: @blue;
     color: @gray-light;
-    font-size: 18px;
+    font-size: 1.8rem;
     transition: background-color, color 0.5s;
     position: relative;
     display: flex;
@@ -108,10 +108,10 @@
         padding: 0 40px;
         text-align: center;
         .libraries-list-label {
-          font-size: 14px;
+          font-size: 1.4rem;
         }
         .libraries-list-content {
-          font-size: 12px;
+          font-size: 1.2rem;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/style/components/footer.less
+++ b/style/components/footer.less
@@ -2,7 +2,7 @@ footer {
   width: 100%;
   background: @green;
   color: @gray-dark;
-  font-size: 12px;
+  font-size: 1.2rem;
   display: flex;
   padding: 10px;
   box-sizing: border-box;

--- a/style/components/general.less
+++ b/style/components/general.less
@@ -7,7 +7,8 @@ body, html {
   height: 100%;
   font-family: @font-family;
   background: @bg;
-  font-size: 16px;
+  /* This allows to use decimal rem units as pixels (i.e 1.6rem = 16px) */
+	font-size: 62.5%;
   line-height: 24px;
   overflow-x: hidden;
 }
@@ -4886,7 +4887,7 @@ button[data-balloon] {
   border-radius: 4px;
   color: #fff;
   content: attr(data-balloon);
-  font-size: 12px;
+  font-size: 1.2rem;
   padding: .5em 1em;
   white-space: nowrap;
   margin-bottom: 11px;

--- a/style/components/header.less
+++ b/style/components/header.less
@@ -44,7 +44,7 @@
     position: relative;
 
     span:not(:last-child) {
-      margin-right: 10px;
+      margin-right: 15px;
     }
 
     a {

--- a/style/components/header.less
+++ b/style/components/header.less
@@ -2,7 +2,7 @@
   width: 100%;
   background: @green;
   color: @gray-dark;
-  font-size: 12px;
+  font-size: 1.2rem;
   display: flex;
   padding: 10px;
   box-sizing: border-box;
@@ -49,6 +49,7 @@
 
     a {
       text-decoration: none;
+      font-size: 1.6rem;
       color: @gray-dark;
       .transition(all, 0.2s);
 

--- a/style/components/select.less
+++ b/style/components/select.less
@@ -10,7 +10,7 @@
     display: inline-block;
     line-height: 1.5em;
     padding: 0.5em 2.5em 0.5em 1em;
-    font-size: 10px;
+    font-size: 1.3rem;
     box-sizing: border-box;
     -webkit-appearance: none;
     -moz-appearance: none;

--- a/style/components/settings.less
+++ b/style/components/settings.less
@@ -41,8 +41,8 @@
       background: @white;
       padding: 10px;
       border: 1px solid darken(@white, 10%);
-      right: 10px;
-      margin-top: 30px;
+      right: 25px;
+      margin-top: 35px;
       top: 0;
       z-index: 999;
       flex-direction: column;

--- a/style/components/settings.less
+++ b/style/components/settings.less
@@ -19,6 +19,8 @@
       }
     }
     & ~ .settings-popup {
+      font-size: 1.4rem;
+
       &:before {
         width: 0;
         height: 0;

--- a/style/components/typography.less
+++ b/style/components/typography.less
@@ -6,12 +6,12 @@ h3 {
 }
 
 h2 {
-  font-size: 20px;
+  font-size: 2rem;
   color: darken(@green, 30%);
 }
 
 h1 {
-    font-size: 24px;
+    font-size: 2.4rem;
 }
 
 p {
@@ -19,7 +19,7 @@ p {
 }
 
 .fa {
-    font-size: 16px;
+    font-size: 1.6rem;
 }
 
 a {
@@ -36,4 +36,5 @@ a {
   width: 70%;
   padding-top: 60px;
   margin: auto;
+  font-size: 1.6rem;
 }

--- a/style/components/typography.less
+++ b/style/components/typography.less
@@ -20,6 +20,11 @@ p {
 
 .fa {
     font-size: 1.6rem;
+
+    &.fa-cog,
+    &.fa-github {
+      font-size: 2.3rem;
+    }
 }
 
 a {

--- a/style/pages/blog.less
+++ b/style/pages/blog.less
@@ -23,12 +23,12 @@
   h1 {
     text-align: center;
     margin-bottom: 50px;
-    font-size: 36px;
+    font-size: 3.6rem;
   }
 
   .date,
   .categories {
-    font-size: 12px;
+    font-size: 1.2rem;
     opacity: .6;
     float: left;
     margin-top: -15px;
@@ -68,8 +68,10 @@
   }
 
   .post {
+    font-size: 1.6rem;
+
     h1 {
-      font-size: 28px;
+      font-size: 2.8rem;
       color: darken(@green, 30%);
     }
   }

--- a/style/partials/media-queries.less
+++ b/style/partials/media-queries.less
@@ -4,7 +4,7 @@
 
     .wrapper .wrapper-header span {
       margin: 0;
-      font-size: 14px;
+      font-size: 1.4rem;
     }
 
     .resizer {
@@ -17,7 +17,7 @@
   }
 
   .header {
-    font-size: 14px !important;
+    font-size: 1.4rem !important;
   }
 }
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Your pull request targets the `develop` branch.
- [X] Branch starts with either `fix/` or `feature/`
- [ ] All new and existing tests pass the command `npm test`.
- [ ] Any new files are included in the grunt tasks

#### Type of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] Tested changes locally.
- [ ] New tests added?
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #231 

#### Full Description of your Changes
This MR increases some font-sizes as well as the icons in the main navigation **without compromising the original layout**.

I changed the `font-size` units from `px` to `rem` to it can be responsive - you can learn more about `rem` units in [this article](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/).  

I also set the `body`'s default font-size to 62.5% so that values like `1.6rem` are compiled to `16px` in the end. This is explained in the article shared before in the section called **Font Sizing with Rem Units**

#### Before
<img width="1552" alt="before" src="https://user-images.githubusercontent.com/4906508/46513084-e92f5e00-c84e-11e8-9e0a-3c688fab304e.png">

#### After
<img width="1552" alt="after" src="https://user-images.githubusercontent.com/4906508/46513086-edf41200-c84e-11e8-9f4c-349888f8a4c2.png">
