### PR TITLE
Feat/ Small Improvements

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from './App';
 
-it('renders without crashing', () => {
+it('renders <App /> without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(<App />, div);
   ReactDOM.unmountComponentAtNode(div);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ import Landing from './components/Landing/Landing';
 import NotFound from './components/NotFound/NotFound';
 
 interface IAppState {
-	headerStyle: string,
 	user?: object
 }
 
@@ -24,27 +23,10 @@ class App extends React.Component<{}, IAppState> {
 	public constructor(props: {}) {
 		super(props);
 		this.state = {
-			headerStyle: "dark",
 			user: undefined,
 		};
-		this.onScroll = this.onScroll.bind(this)
-	}
-	public onScroll() {
-		const elems = Array.prototype.slice.call(document.querySelectorAll('.header-change-light, .header-change-dark'));
-		const elem = elems.find((e: HTMLElement) => {
-			const bounding = e.getBoundingClientRect();
-			return (bounding.top + bounding.height) > 60
-		});
-		if (elem) {
-			const headerStyle = elem.classList.contains('header-change-light') ? 'light' : 'dark'
-			if (this.state.headerStyle !== headerStyle) {
-				this.setState({ headerStyle })
-			}
-		}
 	}
 	public componentDidMount() {
-		window.addEventListener('scroll', this.onScroll)
-		this.onScroll();
 		history.listen((location, action) => {
 			console.log('Change!') // tslint:disable-line
 			// requestAnimationFrame(() => this.onScroll());
@@ -52,20 +34,17 @@ class App extends React.Component<{}, IAppState> {
 	}
 	public render() {
 		return (
-			<div>
-				<Router history={history}>
-					<div>
-						<Header theme={this.state.headerStyle}/>
-						<Switch>
-							<Route exact={true} path="/" component={Landing} />
-							<Route path="/editor" component={Editor} />
-
-							<Route component={NotFound} />
-						</Switch>
-						<Footer />
-					</div>
-				</Router>
-			</div>
+			<Router history={history}>
+				<>
+					<Header />
+					<Switch>
+						<Route exact={true} path="/" component={Landing} />
+						<Route path="/editor" component={Editor} />
+						<Route component={NotFound} />
+					</Switch>
+					<Footer />
+				</>
+			</Router>
 		);
 	}
 }

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import App from '../../App';
+import Header from './Header';
+
+it('renders <Header /> without crashing', () => {
+	const div = document.createElement('div');
+	ReactDOM.render(<App><Header /></App>, div);
+	ReactDOM.unmountComponentAtNode(div);
+});

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,17 +5,42 @@ import './Header.css';
 
 import SearchBox from './SearchBox/SearchBox';
 
-interface IHeaderProps {
+interface IHeaderState {
 	theme: string
 }
 
-export default class Header extends React.Component<IHeaderProps> {
-	public constructor(props: IHeaderProps) {
+export default class Header extends React.Component<{}, IHeaderState> {
+	public constructor(props: {}) {
 		super(props);
+		this.state = {
+			theme: 'dark',
+		};
+
+		this.onScroll = this.onScroll.bind(this)
 	}
+
+	public componentDidMount() {
+		window.addEventListener('scroll', this.onScroll)
+		this.onScroll();
+	}
+
+	public onScroll() {
+		const elems = Array.prototype.slice.call(document.querySelectorAll('.header-change-light, .header-change-dark'));
+		const elem = elems.find((e: HTMLElement) => {
+			const bounding = e.getBoundingClientRect();
+			return (bounding.top + bounding.height) > 60
+		});
+		if (elem) {
+			const theme = elem.classList.contains('header-change-light') ? 'light' : 'dark'
+			if (this.state.theme !== theme) {
+				this.setState({ theme })
+			}
+		}
+	}
+
 	public render() {
 		return (
-			<div className={'header header-' + this.props.theme}>
+			<div className={'header header-' + this.state.theme}>
 				<div className={'header__box'}>
 					<SearchBox />
 				</div>


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Your pull request targets the **`react-redesign`** branch.
- [X] Branch starts with either `fix/` or `feature/`
- [X] All new and existing tests pass the command `npm test`.
- [ ] Any new files are included in the grunt tasks

#### Type of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [X] Tested changes locally.
- [X] New tests added?
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX

#### Changes
* I've moved the `onScroll` functionality from the `<App />` component to the `<Header />` component (see note 1, in the *Notes* section, for clarification)  
* I've made use of React 16's *Fragments* feature - I used the shorthand syntax `<></>` - to avoid cluttering your markup with unnecessary `<div>`s. You can learn a more about Fragments in [this link](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html)
* I also added a unit test simply to mount the `<Header />` component inside `<App />` (see note 2, in the *Notes* section, for more info)

#### Notes
1) As the project grows in development the bigger and more complex your components are going to be, especially App.js. Because of that you should assign responsibilities to the children components so the <App /> doesn't become "overloaded"/cluttered with logic and functionality. Since the "scroll to change the header background" functionality only affects the header I suggest adding a local state to the `<Header />` component to manage its theme.
The theme state could make sense being stored in the App.js if more components had to change.

2) There are functions within the `<Header />` component - like the `onScroll()` -  that should also be unit tested. However I'm still new to unit testing so I simply tested mounting the component for now 😅 
